### PR TITLE
Add Darbot 9bit engine skeleton and docs

### DIFF
--- a/darbot/9bitDrop/9bitDrop.csproj
+++ b/darbot/9bitDrop/9bitDrop.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <UseWinUI>true</UseWinUI>
+    <Platforms>x86;x64;ARM64</Platforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Darbot9BitEngine\Darbot9BitEngine.csproj" />
+  </ItemGroup>
+</Project>

--- a/darbot/9bitDrop/Game.cs
+++ b/darbot/9bitDrop/Game.cs
@@ -1,0 +1,24 @@
+using Darbot9BitEngine;
+
+namespace NineBitDrop
+{
+    public class Game : IGame
+    {
+        public string Name => "9bit Drop";
+
+        public void Initialize(GameContext context)
+        {
+            // TODO: load assets
+        }
+
+        public void Update(GameContext context)
+        {
+            // TODO: game logic
+        }
+
+        public void Render(GameContext context)
+        {
+            // TODO: draw pieces
+        }
+    }
+}

--- a/darbot/9bitDrop/README.md
+++ b/darbot/9bitDrop/README.md
@@ -1,0 +1,5 @@
+# 9bit Drop
+
+This project demonstrates using the Darbot 9bit engine by implementing a simple Tetris clone.
+
+The game registers itself with `GameHost` and drives rendering through the engine loop. Only minimal placeholder code is included.

--- a/darbot/Darbot9BitEngine/App.xaml
+++ b/darbot/Darbot9BitEngine/App.xaml
@@ -1,0 +1,7 @@
+<Application
+    x:Class="Darbot9BitEngine.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/darbot/Darbot9BitEngine/App.xaml.cs
+++ b/darbot/Darbot9BitEngine/App.xaml.cs
@@ -1,0 +1,15 @@
+using Microsoft.UI.Xaml;
+
+namespace Darbot9BitEngine
+{
+    public partial class App : Application
+    {
+        private Window? m_window;
+
+        protected override void OnLaunched(LaunchActivatedEventArgs args)
+        {
+            m_window = new MainWindow();
+            m_window.Activate();
+        }
+    }
+}

--- a/darbot/Darbot9BitEngine/Darbot9BitEngine.csproj
+++ b/darbot/Darbot9BitEngine/Darbot9BitEngine.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <UseWinUI>true</UseWinUI>
+    <Platforms>x86;x64;ARM64</Platforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.0" />
+  </ItemGroup>
+</Project>

--- a/darbot/Darbot9BitEngine/GameContext.cs
+++ b/darbot/Darbot9BitEngine/GameContext.cs
@@ -1,0 +1,7 @@
+namespace Darbot9BitEngine
+{
+    public class GameContext
+    {
+        // Placeholder for timing and rendering resources
+    }
+}

--- a/darbot/Darbot9BitEngine/GameHost.cs
+++ b/darbot/Darbot9BitEngine/GameHost.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace Darbot9BitEngine
+{
+    public class GameHost
+    {
+        private readonly List<IGame> _games = new();
+        private readonly GameContext _context = new();
+
+        public void RegisterGame(IGame game)
+        {
+            _games.Add(game);
+            game.Initialize(_context);
+        }
+
+        public void Update()
+        {
+            foreach (var g in _games)
+            {
+                g.Update(_context);
+            }
+        }
+
+        public void Render()
+        {
+            foreach (var g in _games)
+            {
+                g.Render(_context);
+            }
+        }
+    }
+}

--- a/darbot/Darbot9BitEngine/IGame.cs
+++ b/darbot/Darbot9BitEngine/IGame.cs
@@ -1,0 +1,10 @@
+namespace Darbot9BitEngine
+{
+    public interface IGame
+    {
+        string Name { get; }
+        void Initialize(GameContext context);
+        void Update(GameContext context);
+        void Render(GameContext context);
+    }
+}

--- a/darbot/Darbot9BitEngine/MainWindow.xaml
+++ b/darbot/Darbot9BitEngine/MainWindow.xaml
@@ -1,0 +1,9 @@
+<Window
+    x:Class="Darbot9BitEngine.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="Darbot 9bit">
+    <Grid>
+        <TextBlock Text="Welcome to Darbot 9bit Engine" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</Window>

--- a/darbot/Darbot9BitEngine/MainWindow.xaml.cs
+++ b/darbot/Darbot9BitEngine/MainWindow.xaml.cs
@@ -1,0 +1,13 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Darbot9BitEngine
+{
+    public sealed partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/darbot/darbotreadme.md
+++ b/darbot/darbotreadme.md
@@ -1,0 +1,42 @@
+# Darbot 9bit Engine
+
+Darbot 9bit is a retro-inspired WinApp video game engine. It blends a classic 8‑bit look with modern Fluent design accents. The engine ships with a sample game called **9bit Drop** and provides a lightweight framework so you can build additional voxel‑style games.
+
+## Features
+
+- WinUI 3 desktop application packaged as MSIX
+- Voxel rendering with 9‑bit (8‑bit + smooth edges) aesthetic
+- Modular game loop with scene management
+- Input abstraction for keyboard, mouse, and gamepad
+- Built‑in sample game **9bit Drop** (Tetris clone)
+
+## Building More Games
+
+Games live in their own projects and reference `Darbot9BitEngine`. Each game implements a `IGame` interface and registers itself with the engine.
+
+```
+public interface IGame
+{
+    string Name { get; }
+    void Initialize(GameContext context);
+    void Update(GameContext context);
+    void Render(GameContext context);
+}
+```
+
+See the `9bitDrop` folder for a minimal example.
+
+## Packaging
+
+The solution uses the single‑project MSIX tooling. Running **Publish** in Visual Studio will produce `Darbot9Bit.msix` which installs the engine and sample game.
+
+## Repository Layout
+
+- `Darbot9BitEngine/` – core engine project
+- `9bitDrop/` – sample Tetris implementation
+- `style-guide.md` – design language specification
+- `setup.ps1` – PowerShell setup script for new machines
+
+## License
+
+This sample code is released under the MIT License.

--- a/darbot/setup.ps1
+++ b/darbot/setup.ps1
@@ -1,0 +1,21 @@
+# Install Visual Studio Build Tools and Windows App SDK
+Write-Host 'Installing dependencies...'
+
+# Install winget if not present
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Host 'Winget not found. Please install from the Microsoft Store.'
+    exit 1
+}
+
+winget install --id Microsoft.VisualStudio.2022.Community -e --source winget
+winget install --id Microsoft.WindowsAppSDK -e --source winget
+
+# Enable Developer Mode
+reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWORD /f /v "AllowDevelopmentWithoutDevLicense" /d "1"
+
+# Clone repo
+if (-not (Test-Path Darbot9Bit)) {
+    git clone https://github.com/darbotlabs/darbot-winappsamp.git Darbot9Bit
+}
+
+Write-Host 'Setup complete. Open Darbot9Bit\darbot\Darbot9BitEngine.sln in Visual Studio.'

--- a/darbot/style-guide.md
+++ b/darbot/style-guide.md
@@ -1,0 +1,214 @@
+# Darbot Labs — **Retro Cyber Modern Fluent** Style Guide  
+*Version 1.0 · May 17 2025*
+
+> **Scope**  
+> A single, cross-platform design language from Darbot Labs for all products, including web, mobile, and desktop applications.
+
+---
+
+## 1 Design Principles
+| Pillar | What it means | Practical cues |
+|--------|---------------|----------------|
+| **Retro** | Homage to 8-bit/16-bit UIs & console typefaces | Pixel-grid alignment, low-poly icons, mono fonts |
+| **Cyber** | Neon, terminals, and CRT glow | High-contrast color pops, animated scans & vignettes |
+| **Modern** | Fluent 2 & Material 3 ergonomics | Elevation, rounded corners (4 px / 8 px), 8-pt spacing grid |
+| **Fluent** | Seamless with Windows ecosystem | Acrylic blur, reveal hover, keyboard affordances |
+
+> **Accessibility first** – every color pairing below passes WCAG 2.1 AA for text ≥ 14 pt/1 rem.
+
+---
+
+## 2 Color System
+
+| Role | Token | HEX | Usage |
+|------|-------|-----|-------|
+| **Canvas (0)** | `--grey-100` | `#151515` | App background, video slates |
+| Surface (1) | `--grey-200` | `#1F1F1F` | Cards, modals, side-panels |
+| Surface (2) | `--grey-300` | `#282828` | Input fields, secondary cards |
+| Surface (3) | `--grey-400` | `#3A3A3A` | Toggles, sliders, wells |
+| **Neon Cyan** | `--neon-cyan` | `#779ECB` | Primary brand accent, focus ring |
+| **Neon Magenta** | `--neon-magenta` | `#FF006E` | Highlight, links, headings |
+| **Neon Lime** | `--neon-lime` | `#B8FF00` | Success/online, active states |
+| **Neon Amber** | `--neon-amber` | `#FFBF00` | Warnings, progress, badges |
+| Error | `--neon-red` | `#F31260` | Destructive, offline |
+| Overlay | `--shadow-cya` | `rgba(119,158,203,.35)` | Drop shadows & glows |
+
+```scss
+/* CSS variables (web) */
+:root{
+  --grey-100:#151515;--grey-200:#1f1f1f;--grey-300:#282828;--grey-400:#3a3a3a;
+  --neon-cyan:#779ECB;--neon-magenta:#ff006e;--neon-lime:#b8ff00;--neon-amber:#ffbf00;
+  --neon-red:#f31260;--shadow-cya:rgba(119,158,203,.35);
+}
+```
+
+---
+
+## 3 Typography
+
+| Style      | Font stack (open-source / built-in)                      | Size / Weight |
+| ---------- | -------------------------------------------------------- | ------------- |
+| Display XL | "IBM Plex Mono", "JetBrains Mono", Consolas, monospace | 36 px / 600   |
+| Heading L  | same                                                     | 24 px / 600   |
+| Heading M  | same                                                     | 20 px / 600   |
+| Body M     | "Inter", "Segoe UI", Roboto, system-ui, sans-serif     | 14 px / 400   |
+| Caption    | same                                                     | 12 px / 400   |
+| Mono UI    | "IBM Plex Mono", Consolas, monospace                   | inherit       |
+
+*Why Plex Mono?*
+
+* OFL-licensed (fully open source)
+* Renders crisply at small sizes, preserving retro pixel vibe
+* Variants available for variable-width fallback
+
+> **Implementation**
+> • **Web** – `@font-face` serve **IBM Plex Mono** locally or via a CDN such as cdnjs.
+> • **.NET/WPF** – bundle `IBMPlexMono.ttf` in `Resources` and reference in XAML.
+> • **MAUI / iOS / Android** – add to `Resources/Fonts` and map in `MauiProgram.cs`.
+
+---
+
+## 4 Iconography & Illustrations
+
+*All icons are 1.5-px (desktop) / 2-dp (mobile) strokes.*
+
+| Asset           | Source                        | Color                                   | Notes                                   |
+| --------------- | ----------------------------- | --------------------------------------- | --------------------------------------- |
+| Interface icons | Lucide / Fluent 2 SVG set     | Primary: `--neon-cyan`; hover: glow     | Use `<svg>` stroke + drop shadow filter |
+| Status glyphs   | 8-bit dot/grid sprites        | Lime = online, Magenta = offline        | Animated “pulse” 1 s ease-in-out        |
+| Logos           | Simplified geometric monogram | Magenta brain $AI$ inside Cyan D-shield | Export as SVG & 1024 px PNG             |
+
+---
+
+## 5 Layout, Spacing & Elevation
+
+| Token        | Value                                   | Use                 |
+| ------------ | --------------------------------------- | ------------------- |
+| **Unit**     | 8 px                                    | Base grid           |
+| Card-radius  | 4 px                                    | Compact surfaces    |
+| Panel-radius | 8 px                                    | Elevated containers |
+| Shadow 1     | `0 0 4 px var(--shadow-cya)`            | Inline buttons      |
+| Shadow 2     | `0 0 10 px var(--shadow-cya)`           | Elevated cards      |
+| Glow hover   | `box-shadow:0 0 15 px var(--neon-cyan)` | Interactive focus   |
+
+---
+
+## 6 Core Components (atomic spec)
+
+| Component             | Token ref                                    | States                                                 |
+| --------------------- | -------------------------------------------- | ------------------------------------------------------ |
+| **Button**            | bg `--grey-300` → hover `--neon-cyan`        | *Primary, Secondary, Destructive*                      |
+| **Toggle Switch**     | track `--grey-400` / active `--neon-magenta` | Focus ring `2 px --neon-cyan`                          |
+| **Status Dot**        | 12 px circle                                 | `.online` =`--neon-lime`; `.offline` =`--neon-magenta` |
+| **Card / Panel**      | bg `--grey-300`; border `1 px --neon-cyan`   | Elevation 2 on hover                                   |
+| **Input / Select**    | bg `--grey-400`; text `--neon-cyan`          | Error border =`--neon-red`                             |
+| **Log Box / Console** | mono font, fg `--neon-lime`, bg `--grey-300` | Scroll snap, 200-line cap                              |
+
+<details>
+<summary>Sample CSS Snippet</summary>
+
+```css
+.btn-primary{
+  background:var(--grey-300);
+  color:var(--neon-cyan);
+  border:2px solid var(--neon-cyan);
+  padding:.75rem 1rem;border-radius:4px;
+  transition:all .3s ease;
+}
+.btn-primary:hover,
+.btn-primary:focus-visible{
+  background:var(--neon-cyan);
+  color:var(--grey-100);
+  box-shadow:0 0 15px var(--neon-cyan);
+}
+.toggle input:checked+span{
+  background:var(--neon-magenta);
+}
+.toggle input:checked+span:before{
+  transform:translateX(26px);
+}
+```
+
+</details>
+
+---
+
+## 7 Motion
+
+| Motion token         | Spec                                                                         |
+| -------------------- | ---------------------------------------------------------------------------- |
+| **Hover reveal**     | opacity 0 → 1, 120 ms ease-out                                               |
+| **Focus ring**       | 2 px neon-cyan outline, 60 ms grow                                           |
+| **Toggle knob**      | transform translateX; 400 ms cubic-bezier(.4,0,.2,1)                         |
+| **Shadow breathing** | pulsing glow for active states, `@keyframes breathe 2s ease-in-out infinite` |
+
+---
+
+## 8 Cross-Platform Implementation Cheatsheet
+
+| Platform            | How                                                                                       |
+| ------------------- | ----------------------------------------------------------------------------------------- |
+| **Web**             | Import `style.css` w/ variables; use `prefers-color-scheme` to swap light theme if needed |
+| **WinUI/WPF**       | `ResourceDictionary` keys mirror CSS vars (e.g., `NeonCyanBrush`)                         |
+| **.NET MAUI**       | In `App.xaml`, add `Color x:Key="NeonCyan">#779ECB</Color>`                               |
+| **SwiftUI**         | `Color("NeonCyan")` from `Assets.xcassets`                                                |
+| **Jetpack Compose** | `val NeonCyan = Color(0xFF779ECB)` in `Color.kt`                                          |
+| **Figma**           | Create global paint styles *Neon Cyan*, *Grey 100*, etc.                                  |
+
+---
+
+## 9 Accessibility ⏤ Key Ratios
+
+| Pair                             | Contrast (AA≥4.5) |
+| -------------------------------- | ----------------- |
+| `--neon-cyan` on `--grey-100`    | 4.71 : 1 ✅        |
+| `--neon-magenta` on `--grey-200` | 6.03 : 1 ✅        |
+| `--neon-lime` on `--grey-300`    | 5.87 : 1 ✅        |
+
+*Ensure interactive glows are **in addition** to—not instead of—focus rings.*
+
+---
+
+## 10 Brand Voice & Tone
+
+| Attribute       | Guideline                                                            |
+| --------------- | -------------------------------------------------------------------- |
+| **Voice**       | Confident, engineer-friendly, slightly playful                       |
+| **Tone**        | Encourage experimentation (“Hack the limits”), avoid jargon overload |
+| **Microcopy**   | Imperatives: “Start Service”, “Toggle Fallback”                      |
+| **Easter Eggs** | Subtle ASCII art in console, 1 line max                              |
+
+---
+
+## 11 Asset Kit
+
+* **Fonts**: `IBM Plex Mono` (OFL), `Inter` (OFL) → `/assets/fonts/`
+* **SVG Icon set** → `/assets/icons/`
+* **Logo variants** (`primary.svg`, `mono.svg`, `favicon.ico`)
+* **Motion presets** (`.json` Lottie, `.gif` sparkline demos)
+
+---
+
+## 12 Versioning & Governance
+
+| Rule                   | Detail                                                                      |
+| ---------------------- | --------------------------------------------------------------------------- |
+| SemVer                 | Major (breaking design shift) · Minor (new component) · Patch (token tweak) |
+| Review cadence         | Monthly design review; PR required for palette changes                      |
+| Single source of truth | `/design/tokens/` JSON + Figma styles sync                                  |
+
+---
+
+### Quick-Start Snippet (Web)
+
+```html
+<link rel="stylesheet" href="darbot-style.min.css">
+<body class="dark">
+  <button class="btn-primary">Start Service</button>
+</body>
+```
+
+---
+
+© 2025 Darbot Labs. Licensed under MIT for internal & community tooling.
+*Retro vibes, modern flows.*


### PR DESCRIPTION
## Summary
- add retro cyber modern fluent style guide
- scaffold Darbot 9bit game engine and sample game
- include setup script and explanatory README

## Testing
- `git status --short`